### PR TITLE
Line notification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,9 @@ gem 'aws-sdk-s3', require: false
 gem 'carrierwave-aws'
 gem 'kaminari'
 gem 'meta-tags'
-gem 'dotenv-rails'
+gem 'dotenv-rails' #環境変数
 gem 'config'
+gem 'line-bot-api'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
       letter_opener (~> 1.7)
       railties (>= 5.2)
       rexml
+    line-bot-api (1.28.0)
     loofah (2.21.4)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -408,6 +409,7 @@ DEPENDENCIES
   jsbundling-rails
   kaminari
   letter_opener_web
+  line-bot-api
   meta-tags
   mini_magick
   pg

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,7 +1,9 @@
 class LinebotController < ApplicationController
+  skip_before_action :require_login, only: [:callback]
+
   require 'line/bot'
 
-  protect_from_forgery expect: :callback
+  protect_from_forgery except: :callback
 
   def client
     @client ||= Line::Bot::Client.new { |config|
@@ -19,6 +21,7 @@ class LinebotController < ApplicationController
       head :bad_request
     end
 
+    events = client.parse_events_from(body)
     events.each do |event|
       case event
       when Line::Bot::Event::Message
@@ -34,14 +37,22 @@ class LinebotController < ApplicationController
   def handle_message(event)
     case event.type
     when Line::Bot::Event::MessageType::Text
-      message = {
-        type: 'text',
-        text: event.message['text']
-      }
+      message_text = event.message['text']
+      
+      message = case message_text 
+                when '現在受検できる級を確認したい'
+                  {
+                    type: 'text',
+                    text: "日本編 🇯🇵 \n 熊本、宮崎、三重、兵庫、群馬 \n \n 海外編 🌍 \n カナダ、オランダ、フィンランド、マルタ、ベトナム"
+                  }
+                else
+                  {
+                    type: 'text',
+                    text: "このアカウントは通知専用ですので、ご質問等はお問い合わせフォームからお願いします🙇🏼"
+                  }
+                end
+
       client.reply_message(event['replyToken'], message)
     end
   end
-
-
-
 end

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,0 +1,47 @@
+class LinebotController < ApplicationController
+  require 'line/bot'
+
+  protect_from_forgery expect: :callback
+
+  def client
+    @client ||= Line::Bot::Client.new { |config|
+      config.channel_id = ENV["LINE_CHANNEL_ID"]
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+  }
+  end
+
+  def callback
+    body = request.body.read
+    signature = request.env['HTTP_X_LINE_SIGNATURE']
+
+    unless client.validate_signature(body, signature)
+      head :bad_request
+    end
+
+    events.each do |event|
+      case event
+      when Line::Bot::Event::Message
+        handle_message(event)
+      end
+    end
+
+    render plain: "OK"
+  end
+
+  private 
+
+  def handle_message(event)
+    case event.type
+    when Line::Bot::Event::MessageType::Text
+      message = {
+        type: 'text',
+        text: event.message['text']
+      }
+      client.reply_message(event['replyToken'], message)
+    end
+  end
+
+
+
+end

--- a/app/helpers/linebot_helper.rb
+++ b/app/helpers/linebot_helper.rb
@@ -1,0 +1,2 @@
+module LinebotHelper
+end

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:title, t('.title'))%>
-<div class="container md:pt-5 pt-10 mb-52 md:pt-20 mx-auto h-screen font-sans font-light">
+<div class="container md:pt-5 pt-10 mb-96 md:pt-20 mx-auto h-screen font-sans font-light">
   <div class="flex justify-end pt-20 px-5">
     <%= image_tag 'plane.png', class:"md:w-1/5 w-24"%>
   </div>
@@ -23,12 +23,20 @@
       <%= f.submit t('defaults.login'), class:"btn primary btn-lg bg-zinc-700 text-white" %>
     </div>
   <% end %>
-  <div class="container rounded-lg bg-purple-50 bg-opacity-90 mt-10 md:mb-0 mx-auto py-10 md:w-96 w-72">
+  <div class="container rounded-lg bg-purple-50 bg-opacity-90 mt-10 md:mb-0 mx-auto py-10 md:w-96 w-72 shadow-inner shadow-purple-300">
     <div class="md:text-xl text-center">
       <%= link_to t('users.new.new_user'), new_user_path, class:"underline underline-offset-8" %>
     </div>
     <div class="md:text-xl text-center pt-5">
       <%= link_to t('defaults.for_password_reset'), new_password_reset_path, class:"underline underline-offset-8" %>
     </div>
+    <!-- LINE Messaging -->
+    <div class="md:text-xl pt-14 text-center font-bold text-green-600">
+      <p>LINE友だち追加</p>
+      <div class="pt-2 mx-auto text-center w-28">
+        <%= image_tag "https://qr-official.line.me/gs/M_843iulty_BW.png?oat_content=qr" %>
+      </div>
+    </div>
   </div>
+  
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,8 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  #Line Messagingの確認をするため
+  config.hosts << '.ngrok.io'
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,9 @@ Rails.application.routes.draw do
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
+
+  post '/callback', to: 'linebot#callback' #Line Messaging
   
-  #get 'japan_and_overseas_test_categories', to: 'japan_and_overseas_test_categories#index', as: 'place'
-  #get 'quizzes/:category_name', to: 'quizzes#index'
   get 'passed_lists', to: 'passed_lists#index'
   get 'sample_quiz', to: 'quizzes#sample_quiz'
 

--- a/test/controllers/linebot_controller_test.rb
+++ b/test/controllers/linebot_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LinebotControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

・Line通知を実装

## チェックリスト

- [ ] ログイン画面に友達追加ができるQRコードが表示されている
- [ ] QRコードを読み込むと勘検定のアカウントと友達になれる
- [ ] 友達を追加すると挨拶のメッセージが返ってくる（Lineから設定している）
- [ ] 「現在受検できる級を確認したい」のメニューを選択すると受検可能なカテゴリー一覧がメッセージを返す
- [ ] その他のメッセージをもらうと「このアカウントは通知専用ですので、ご質問等はお問い合わせフォーム〜〜〜」を返す

##メモ
上記、開発で全てクリア
