### PR TITLE
Searching by turbo

### DIFF
--- a/app/views/test_categories/_regions.html.erb
+++ b/app/views/test_categories/_regions.html.erb
@@ -1,6 +1,6 @@
 <% categories.each do |category| %>
   <% if category.region == region %>
-    <p><%= link_to category.title, category_reviews_path(category) %></p>
+    <p><%= link_to category.title, category_reviews_path(category), data: {  turbo: false } %></p>
   <% end %>
 <% end %>
 

--- a/app/views/test_categories/_search_form.html.erb
+++ b/app/views/test_categories/_search_form.html.erb
@@ -1,12 +1,15 @@
-<%= search_form_for @q, url: categories_path, method: :get do |f| %>
+<%= search_form_for @q, url: categories_path, method: :get, html: { data: { turbo_frame: "category_list" } } do |f| %>
   <div class="flex justify-center space-x-20 md:pr-10">
-    <div class="flex space-x-1 pt-10 md:pt-20 px-5 justify-center">
+    <div class="md:flex space-x-1 pt-10 md:pt-20 px-5 justify-center">
       <div data-controller="autocomplete" data-autocomplete-url-value="<%= search_result_categories_path %>" role="combobox">
         <%= f.search_field :title_cont, data: { autocomplete_target: 'input' }, class: "input input-bordered w-full rounded-lg", placeholder: "都道府県名・国名" %>
         <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
         <ul class="list-group" data-autocomplete-target="results"></ul>
       </div>
-      <%= f.submit t('defaults.search'), class: "btn btn-md btn-outline bg-gray-700 text-white text-base" %>
+      <div class="md:flex space-x-0 text-center">
+        <%= link_to t('test_comments.index.reset'), categories_path, class: "btn md:btn-md btn-outline bg-color-400 text-white text-base md:mt-0 mt-5" %>
+        <%= f.submit t('defaults.search'), class: "btn btn-md btn-outline bg-gray-700 text-white text-base" %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/test_categories/index.html.erb
+++ b/app/views/test_categories/index.html.erb
@@ -10,32 +10,34 @@
   <%= render 'search_form' %>
 
   <!--サンプル問題の続き-->
-  <div class="flex justify-center pt-10 px-10 text-center">
+  <div class="flex justify-center md:pt-10 pt-20 px-10 text-center">
     <p class="text-lg md:text-2xl font-bold md:pb-20">サンプル問題(ベトナム級)の続きは<%= link_to "こちらから", category_reviews_path(@vietnam_quiz), class:"underline underline-offset-8 cursor-pointe" %>
   </div>
 
   <!--カテゴリ-->
-  <div class="md:mr-26 md:mx-auto ml-8 md:mt-5 mt-20 flex flex-col md:flex-row justify-center md:space-x-20">
-    <% if @categories.any? %>
-      <div class="md:px-20 px-12 md:max-w-fit w-11/12 pb-5 rounded-lg bg-neutral-50 bg-opacity-90">
-        <p class="pb-5 pt-3 text-xl text-center font-black">🇯🇵 日本編 🇯🇵</p>
-        <div class="flex grid grid-cols-2 gap-4 whitespace-nowrap px-10 h-fit md:text-xl text-md">
-          <%= render 'regions', { categories: @categories, region: 'japan'} %>
+  <%= turbo_frame_tag "category_list" do %>
+    <div class="md:mr-26 md:mx-auto ml-8 md:mt-5 mt-20 flex flex-col md:flex-row justify-center md:space-x-20">
+      <% if @categories.present? %>
+        <div class="md:px-20 px-12 md:max-w-fit w-11/12 pb-5 rounded-lg bg-neutral-50 bg-opacity-90">
+          <p class="pb-5 pt-3 text-xl text-center font-black">🇯🇵 日本編 🇯🇵</p>
+          <div class="flex grid grid-cols-2 gap-4 whitespace-nowrap px-10 h-fit md:text-xl text-md">
+            <%= render 'regions', { categories: @categories, region: 'japan'} %>
+          </div>
         </div>
-      </div>
-      <div class="md:pl-5 pl-5 pr-3 md:mt-0 mt-5 md:max-w-fit w-11/12 pb-5 rounded-lg bg-neutral-50 bg-opacity-90">
-        <p class="pb-5 pt-3 text-xl text-center font-black">🌎 海外編 🌍</p>
-        <div class="flex grid grid-cols-2 gap-3 whitespace-pre px-10 h-fit md:text-xl text-md">
-          <%= render 'regions', { categories: @categories, region: 'foreign'} %>
+        <div class="md:pl-5 pl-5 pr-3 md:mt-0 mt-5 md:max-w-fit w-11/12 pb-5 rounded-lg bg-neutral-50 bg-opacity-90">
+          <p class="pb-5 pt-3 text-xl text-center font-black">🌎 海外編 🌍</p>
+          <div class="flex grid grid-cols-2 gap-3 whitespace-pre px-10 h-fit md:text-xl text-md">
+            <%= render 'regions', { categories: @categories, region: 'foreign'} %>
+          </div>
         </div>
-      </div>
-    <% else %>
-      <div class="flex items-center">
-        <%= image_tag 'sorry.png', class: "w-20" %>
-        <p class="md:text-2xl text-xl">お探しの検定は見つかりませんでした。</p>
-      </div>
-    <% end %>
-  </div>
+      <% else %>
+        <div class="flex items-center rounded-lg bg-neutral-50 bg-opacity-90 p-10 md:mx-auto mr-8">
+          <%= image_tag 'sorry.png', class: "w-20" %>
+          <p class="md:text-2xl text-xl">お探しの検定は見つかりませんでした。</p>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 
   <!--googlemap-->
   <p class="pt-20 pb-5 md:text-left text-center md:pl-20 px-8">これから受検する級の位置を確認すると、何かヒントになるかもしれません！</p>

--- a/app/views/test_comments/_crud_menus.html.erb
+++ b/app/views/test_comments/_crud_menus.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= link_to edit_category_test_comment_path(category, test_comment) do %>
+  <%= link_to edit_category_test_comment_path(category, test_comment), data: { turbo: false } do %>
     <i class="fa-solid fa-pen-to-square"></i>
   <% end %>
 </div>

--- a/app/views/test_comments/_search_form.html.erb
+++ b/app/views/test_comments/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for @q, url: category_test_comments_path, method: :get do |f| %>
+<%= search_form_for @q, url: category_test_comments_path, method: :get, html: { data: { turbo_frame: "comment_list" } } do |f| %>
   <div class="flex justify-center space-x-20">
     <div class="flex flex-col md:flex-row space-x-2 pt-10 md:pt-20 px-5 justify-center">
       <div data-controller="autocomplete" data-autocomplete-url-value="<%= search_content_category_test_comments_path %>" role="combobox">

--- a/app/views/test_comments/_test_comment.html.erb
+++ b/app/views/test_comments/_test_comment.html.erb
@@ -30,7 +30,7 @@
           <i class="fa-brands fa-square-x-twitter"></i>
         <% end %>
       </div>
-      <%= render 'crud_menus', test_comment: test_comment, category: category  %>
+      <%= render 'crud_menus', test_comment: test_comment, category: category %>
     <% end %>
   </div>
 </div>

--- a/app/views/test_comments/edit.html.erb
+++ b/app/views/test_comments/edit.html.erb
@@ -3,8 +3,8 @@
   <div class="pt-32 md:text-3xl text-2xl mx-auto text-center">
     <h1>コメント編集</h1>
     <% if @souvenir.explanation.present? %>
-      <div class="rounded-lg bg-neutral-50 bg-opacity-90 p-3 w-fit mx-auto mt-16 md:text-xl text-base">
-        <p>獲得したお土産：<%= @test_comment.souvenir_photo.name %></p>
+      <div class="rounded-lg bg-neutral-50 bg-opacity-90 py-3 px-10 w-fit md:mx-auto mt-16 md:text-xl text-base">
+        <p class="bg-emerald-100 rounded-full pb-1">お土産：<%= @test_comment.souvenir_photo.name %></p>
         <%= @test_comment.souvenir_photo.explanation.present? ?  @test_comment.souvenir_photo.explanation : "" %>
       </div>
     <% end %>

--- a/app/views/test_comments/index.html.erb
+++ b/app/views/test_comments/index.html.erb
@@ -5,23 +5,27 @@
 
     <!--検索-->
     <%= render 'search_form' %>
-    <% if @test_comments.present? %>
-      <div class="md:grid md:grid-cols-2 md:gap-4 flex flex-wrap place-items-center pt-20 justify-center px-5">
-        <%= render @test_comments, category: @category, souvenir: @souvenir %>
-      </div>
-      <div class="flex justify-center pb-10">
-        <% if params[:from_passed_list] == "true" %>
-          <%= link_to t('defaults.back'), passed_lists_path, class:"btn primary btn-lg bg-zinc-700 text-white" %>
-        <% else %>
-          <%= link_to t('defaults.categories'), categories_path,  class:"btn primary btn-lg bg-zinc-700 text-white" %>
-        <% end %>
-      </div>
-    <% else %>
-      <div class="flex items-center justify-center pt-20 pb-60 px-10">
-        <%= image_tag 'sorry.png', class: "w-20" %>
-        <p class="md:text-2xl text-xl">お探しの内容は見つかりませんでした。</p>
-      </div>
+
+    <!-- コメント一覧 -->
+    <%= turbo_frame_tag "comment_list" do %>
+      <% if @test_comments.present? %>
+        <div class="md:grid md:grid-cols-2 md:gap-4 flex flex-wrap place-items-center pt-20 justify-center px-5">
+          <%= render @test_comments, category: @category, souvenir: @souvenir %>
+        </div>
+      <% else %>
+        <div class="flex items-center rounded-lg bg-neutral-50 bg-opacity-90 p-10 mt-10 mb-10 md:mx-auto mr-8 w-fit">
+          <%= image_tag 'sorry.png', class: "w-20" %>
+          <p class="md:text-2xl text-xl">お探しの内容は見つかりませんでした。</p>
+        </div>
+      <% end %>
     <% end %>
+    <div class="flex justify-center pb-10">
+      <% if params[:from_passed_list] == "true" %>
+        <%= link_to t('defaults.back'), passed_lists_path, class:"btn primary btn-lg bg-zinc-700 text-white" %>
+      <% else %>
+        <%= link_to t('defaults.categories'), categories_path,  class:"btn primary btn-lg bg-zinc-700 text-white" %>
+      <% end %>
+    </div>
 
     <!--ページネーション-->
     <div class="py-10">

--- a/app/views/top_pages/top.html.erb
+++ b/app/views/top_pages/top.html.erb
@@ -1,16 +1,14 @@
 <div>
   <div class="md:flex pt-6">
-    <div class="w-screen pt-10">
-      <picture>
-        <source srcset="<%= asset_path('top_image.webp') %>" type="image/webp">
-        <img src="<%= asset_path('top_image.jpeg') %>" alt="Top image">
-      </picture>
-    </div>
-    <div class="md:mt-20 mt-10 md:mr-10 mx-24">
-      <p class="text-center md:text-4xl text-4xl md:pt-20 pt-10"><span class="bg-amber-100 rounded-full px-3 pb-1">勘</span>を</p>
-      <p class="text-center md:text-4xl text-4xl pt-2">使って旅に</p>
-      <p class="text-center md:text-4xl text-4xl py-1">出ません</p>
-      <p class="text-center md:text-4xl text-4xl py-1">か？</p>
+    <picture class="screen pt-10">
+      <source srcset="<%= asset_path('top_image.webp') %>" type="image/webp">
+      <img src="<%= asset_path('top_image.jpeg') %>" alt="Top image">
+    </picture>
+    <div class="md:mt-32 mt-10 mx-24 md:text-4xl text-4xl">
+      <p class="text-center md:pt-20 pt-10"><span class="bg-amber-100 rounded-full px-3 pb-1">勘</span>を</p>
+      <p class="text-center pt-2">使って旅に</p>
+      <p class="text-center py-1">出ません</p>
+      <p class="text-center py-1">か？</p>
       <p class="md:text-xl text-xl flex justify-center mb-10 md:pt-5 pt-5 font-bold">- 勘検定 -</p>
     </div>
   </div>


### PR DESCRIPTION
## 概要

・turbo_frameを使って特定の部分だけがリロード（パフォーマンスの向上のため）
・topページ、コメント編集画面のレイアウトを調整

## チェックリスト

- [x] 検索する時にページ全体がリロードしない
- [x] 特定のカテゴリー、ページに飛べる（turbo_frameがfalseになって、次のページ遷移に影響していない）

